### PR TITLE
Fix getting root dir from project instance

### DIFF
--- a/helm-file-preview.el
+++ b/helm-file-preview.el
@@ -164,7 +164,7 @@ ARGS : rest of the arguments."
 
 ;;;###autoload
 (define-minor-mode helm-file-preview-mode
-  "Minor mode 'helm-file-preview-mode'."
+  "Minor mode `helm-file-preview-mode'."
   :global t
   :require 'helm-file-preview
   :group 'helm-file-preview

--- a/helm-file-preview.el
+++ b/helm-file-preview.el
@@ -67,6 +67,11 @@
 
 ;;; Core
 
+(declare-function project-root "project" (project))
+(when (version< emacs-version "28.0.90")
+  (defun project-root (project)
+    (cdr project)))
+
 (defun helm-file-preview--do-preview (fp ln cl)
   "Do preview with filepath (FP), line number (LN), column (CL)."
   (let (did-find-file)

--- a/helm-file-preview.el
+++ b/helm-file-preview.el
@@ -105,7 +105,7 @@ ARGS : rest of the arguments."
              (fn (nth 0 sel-lst))   ; filename
              (ln (nth 1 sel-lst))   ; line
              (cl (nth 2 sel-lst))   ; column
-             (root (cdr (project-current)))
+             (root (project-root (project-current)))
              (fp (concat root fn))  ; file path
              )
         ;; NOTE: Try expand file, if the file not found relative to


### PR DESCRIPTION
I reinstalled my Emacs 29.0.50 today which apparently fixed some issues, because it seems I had some outdated libraries symlinked. But in return `helm-projectile` with `helm-file-preview-mode` enabled got broken with the following message:

```
let*: Wrong type argument: characterp, git
```

A little debugging revealed the form `(root (cdr (project-current)))` as the culprit. Apparently the format of the project instance changed in https://git.savannah.gnu.org/cgit/emacs.git/commit/lisp/progmodes/project.el?id=86969f9658e278ebacb3d625d0309046ff1f2b54. But to my understanding the exact format is an implementation detail anyway which shouldn't be relied on. Instead the generic functions like `project-root` are supposed to be used, which is what this PR proposes to do.

This should be backwards compatible since the `project-root` generic is available since the beginning: https://git.savannah.gnu.org/cgit/emacs.git/commit/lisp/progmodes/project.el?id=f8c720b55b9419c849ea9febe6f888761a61949b.